### PR TITLE
feat(windows-terminal): color scheme to `Dark+`

### DIFF
--- a/WindowsTerminal/settings.json
+++ b/WindowsTerminal/settings.json
@@ -138,9 +138,8 @@
   "newTabPosition": "afterCurrentTab",
   "profiles": {
     "defaults": {
-      "adjustIndistinguishableColors": "indexed",
       "bellStyle": "none",
-      "colorScheme": "Solarized Dark",
+      "colorScheme": "Dark+",
       "font": {
         "face": "HackGen Console NF"
       },


### PR DESCRIPTION
Claude Codeが`Solarized Dark`だと読めない配色を繰り返すので、
シェル側が折れることにします。
既にGNU/Linux側のkittyは黒背景にしてるし。
