### PR TITLE
feat(WindowsTerminal): set Modus Vivendi as default

### DIFF
--- a/WindowsTerminal/settings.json
+++ b/WindowsTerminal/settings.json
@@ -70,7 +70,7 @@
   "profiles": {
     "defaults": {
       "bellStyle": "none",
-      "colorScheme": "Dark+",
+      "colorScheme": "Modus Vivendi",
       "font": {
         "face": "FirgeNerd Console"
       },
@@ -111,7 +111,31 @@
       }
     ]
   },
-  "schemes": [],
+  "schemes": [
+    {
+      "name": "Modus Vivendi",
+      "background": "#000000",
+      "foreground": "#ffffff",
+      "cursorColor": "#ffffff",
+      "selectionBackground": "#5a5a5a",
+      "black": "#000000",
+      "red": "#ff5f59",
+      "green": "#44bc44",
+      "yellow": "#d0bc00",
+      "blue": "#2fafff",
+      "purple": "#feacd0",
+      "cyan": "#00d3d0",
+      "white": "#a6a6a6",
+      "brightBlack": "#595959",
+      "brightRed": "#ff6b55",
+      "brightGreen": "#00c06f",
+      "brightYellow": "#fec43f",
+      "brightBlue": "#79a8ff",
+      "brightPurple": "#b6a0ff",
+      "brightCyan": "#6ae4b9",
+      "brightWhite": "#ffffff"
+    }
+  ],
   "theme": "system",
   "themes": [],
   "warning.confirmCloseAllTabs": true,


### PR DESCRIPTION
- Add Modus Vivendi color scheme to terminal settings
- Set Modus Vivendi as the default color scheme for all profiles

close #11 